### PR TITLE
Allow optional charset in source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 let { readFileSync } = require("fs");
-let regex = /sourceMappingURL=data:application\/json;base64,(\S+)/;
+let regex = /sourceMappingURL=data:application\/json;(?:charset=utf-8;)base64,(\S+)/;
 
 module.exports = (fileName, attributes) => {
 	let result = regex.exec(readFileSync(fileName));


### PR DESCRIPTION
> source maps generated by Rollup include charset as an additional media-type
> parameter:
> 
>     //# sourceMappingURL=data:application/json;charset=utf-8;base64,…
> 
> of course hard-coding that parameter like this is brittle too; it seems
> to me that RegEx-based parsing is not particularly suitable here